### PR TITLE
Add HF integration

### DIFF
--- a/core/foundation_stereo.py
+++ b/core/foundation_stereo.py
@@ -7,6 +7,8 @@
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 
 
+import argparse
+
 import torch,pdb,logging,timm
 import torch.nn as nn
 import torch.nn.functional as F
@@ -124,8 +126,18 @@ class hourglass(nn.Module):
 
 
 
-class FoundationStereo(nn.Module, huggingface_hub.PyTorchModelHubMixin):
-    def __init__(self, args):
+class FoundationStereo(nn.Module, huggingface_hub.PyTorchModelHubMixin,
+                       repo_url="https://github.com/NVlabs/FoundationStereo",
+                       paper_url="https://huggingface.co/papers/2501.09898",
+                       pipeline_tag="depth-estimation",
+                       license="other",
+                       coders={
+                            argparse.Namespace : (
+                                lambda x: vars(x),
+                                lambda data: argparse.Namespace(**data),
+                            )
+   }):
+    def __init__(self, args: argparse.Namespace):
         super().__init__()
         self.args = args
 


### PR DESCRIPTION
This PR ensures the FoundationStereo model can be pushed and loaded to and from the 🤗 hub.

It equips the main model class with:

* `from_pretrained`, `save_pretrained`and`push_to_hub` capabilities
* safetensors for weights serialization (if you do `model.save_pretrained("...")` or `model.push_to_hub("...")`)
* track download numbers for models pushed to the hub, similar to models in the Transformers library
* push an automated model card.

It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherits these methods.

Usage is as follows:

```python
from core.foundation_stereo import FoundationStereo

model = FoundationStereo(...)

# save it locally like so
model.save_pretrained("my-foundation-stereo-model")

# or push a trained model to the hub
model.push_to_hub("nvidia/foundation-stereo")

# now anyone can use it like so
model = FoundationStereo.from_pretrained("nvidia/foundation-stereo")
```