### PR TITLE
small localized updates for 1.2% to 2.4% speedup

### DIFF
--- a/core/foundation_stereo.py
+++ b/core/foundation_stereo.py
@@ -38,7 +38,7 @@ def normalize_image(img):
     '''
     @img: (B,C,H,W) in range 0-255, RGB order
     '''
-    tf = torchvision.transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225], inplace=False)
+    tf = torchvision.transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225], inplace=True)
     return tf(img/255.0).contiguous()
 
 

--- a/core/geometry.py
+++ b/core/geometry.py
@@ -49,14 +49,12 @@ class Combined_Geo_Encoding_Volume:
             x0 = self.dx + disp.reshape(b*h*w, 1, 1, 1) / 2**i
             y0 = torch.zeros_like(x0)
 
-            disp_lvl = torch.cat([x0,y0], dim=-1)
-            geo_volume = bilinear_sampler(geo_volume, disp_lvl, low_memory=low_memory)
+            geo_volume = bilinear_sampler(geo_volume, x0)
             geo_volume = geo_volume.reshape(b, h, w, -1)
 
             init_corr = self.init_corr_pyramid[i]
             init_x0 = coords.reshape(b*h*w, 1, 1, 1)/2**i - disp.reshape(b*h*w, 1, 1, 1) / 2**i + self.dx   # X on right image
-            init_coords_lvl = torch.cat([init_x0,y0], dim=-1)
-            init_corr = bilinear_sampler(init_corr, init_coords_lvl, low_memory=low_memory)
+            init_corr = bilinear_sampler(init_corr, init_x0)
             init_corr = init_corr.reshape(b, h, w, -1)
 
             out_pyramid.append(geo_volume)

--- a/core/utils/utils.py
+++ b/core/utils/utils.py
@@ -41,17 +41,14 @@ class InputPadder:
         return x[..., c[0]:c[1], c[2]:c[3]]
 
 
-def bilinear_sampler(img, coords, mode='bilinear', mask=False, low_memory=False):
+def bilinear_sampler(img, xgrid):
     """ Wrapper for grid_sample, uses pixel coordinates """
     H, W = img.shape[-2:]
-    xgrid, ygrid = coords.split([1,1], dim=-1)
+    assert H == 1 # This is a stereo problem
     xgrid = 2*xgrid/(W-1) - 1   # Normalize to [-1,1]
-    assert torch.unique(ygrid).numel() == 1 and H == 1 # This is a stereo problem
+    ygrid = torch.zeros_like(xgrid)
     grid = torch.cat([xgrid, ygrid], dim=-1).to(img.dtype)
     img = F.grid_sample(img, grid, align_corners=True)
-    if mask:
-        mask = (xgrid > -1) & (ygrid > -1) & (xgrid < 1) & (ygrid < 1)
-        return img, mask.float()
     return img
 
 


### PR DESCRIPTION
This update maintains functional parity while bringing 1.2% to 2.4% speedup.
The updates are small and localized as follows:

1. allow the input images normalizer to be in_place, because the input is first divided by 255.0 and that already is a not-inplace operation (hence already safe). This accounts for roughly 50% of said speedup.
2. utils/bilinear_sampler no longer accepts a generic ygrid only to enforce that it is suitable for rectified stereo (zeros). Instead create the zeros inline. This accounts for roughly 50% of said speedup.

Finally, note that bilinear_sampler is only invoked from geometry/Combined_Geo_Encoding_Volume.__call__ . I removed the 3 extra parameters to it that are dead-code (mode, mask and low_memory). While this doesn't contribute to the speedup, it simplifies the bilinear_sampler interface.

Testing done:
1. executed scripts/run_demo.py before and after and visually the point-cloud looked the same
2. executed scripts/run_demo.py before and after, saving the resulting "disp" tensor to separate files, then I confirmed they are identical
3. I'm also using FoundationStereo in the context of 3D reconstruction for scenes with 100-300 stereo pairs, 640 x 640 x 3. This is where I measured the speedup gains: 1.2% on some scenes, 2.4% on others. Also, these updates don't appear to affect the reconstructed scenes.

P.S. Thank you for creating FoundationStereo!