### PR TITLE
fix: Resolve cuDNN error during hierarchical inference

### DIFF
--- a/core/utils/utils.py
+++ b/core/utils/utils.py
@@ -12,7 +12,7 @@ import torch,pdb,logging
 import torch.nn.functional as F
 import numpy as np
 from scipy import interpolate
-
+import torch.backends.cudnn as cudnn
 
 class InputPadder:
     """ Pads images such that dimensions are divisible by 8 """
@@ -48,7 +48,8 @@ def bilinear_sampler(img, coords, mode='bilinear', mask=False, low_memory=False)
     xgrid = 2*xgrid/(W-1) - 1   # Normalize to [-1,1]
     assert torch.unique(ygrid).numel() == 1 and H == 1 # This is a stereo problem
     grid = torch.cat([xgrid, ygrid], dim=-1).to(img.dtype)
-    img = F.grid_sample(img.contiguous(), grid.contiguous(), align_corners=True)
+    with cudnn.flags(enabled=False):
+        img = F.grid_sample(img.contiguous(), grid.contiguous(), align_corners=True)
     if mask:
         mask = (xgrid > -1) & (ygrid > -1) & (xgrid < 1) & (ygrid < 1)
         return img, mask.float()


### PR DESCRIPTION
The `F.grid_sample` operation was causing a `CUDNN_STATUS_NOT_SUPPORTED` runtime error when running hierarchical inference (`hiera=1`). This typically occurs when a non-contiguous tensor is passed to a cuDNN-accelerated function.

This commit resolves the issue by wrapping the `F.grid_sample` call inside a `cudnn.flags(enabled=False)` context manager. This forces PyTorch to use its native CUDA implementation for the operation, which is more robust to memory layout variations and avoids the cuDNN compatibility error.
