### PR TITLE
fix(run-demo-batch): argparse --get_pc uses type=bool (+2 more)

### DIFF
--- a/scripts/run_demo_batch.py
+++ b/scripts/run_demo_batch.py
@@ -34,9 +34,10 @@ def set_seed(random_seed):
     np.random.seed(random_seed)
     random.seed(random_seed)
     torch.manual_seed(random_seed)
-    torch.cuda.manual_seed_all(random_seed)
-    torch.backends.cudnn.deterministic = True
-    torch.backends.cudnn.benchmark = False
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(random_seed)
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
 
 class CuSFMDataInference:
     def __init__(self, args):
@@ -378,7 +379,7 @@ if __name__ == "__main__":
         default=32,
         help='number of flow-field updates during forward pass')
     parser.add_argument(
-        '--get_pc', type=bool, default=False, help='get point cloud output')
+        '--get_pc', action='store_true', help='get point cloud output')
     parser.add_argument(
         '--z_far',
         default=10,
@@ -397,8 +398,7 @@ if __name__ == "__main__":
         '--num_gpus', type=int, default=1, help='number of GPUs to use')
     parser.add_argument(
         '--also_generate_for_right_camera',
-        type=bool,
-        default=False,
+        action='store_true',
         help='whether to generate depth for right camera')
     args = parser.parse_args()
 


### PR DESCRIPTION
Small fixes in `scripts/run_demo_batch.py`:

#### fix: argparse --get_pc uses type=bool instead of store_true

**Fix:** Replace:
```
    parser.add_argument(
        '--get_pc', type=bool, default=False, help='get point cloud output')
```

with:
```
    parser.add_argument(
        '--get_pc', action='store_true', help='get point cloud output')
```

#### fix: argparse --also_generate_for_right_camera uses type=bool

**Fix:** Replace:
```
    parser.add_argument(
        '--also_generate_for_right_camera',
        type=bool,
        default=False,
        help='whether to generate depth for right camera')
```

with:
```
    parser.add_argument(
        '--also_generate_for_right_camera',
        action='store_true',
        help='whether to generate depth for right camera')
```

#### fix: set_seed crashes on CPU-only systems

**Fix:** Replace:
```
def set_seed(random_seed):
    np.random.seed(random_seed)
    random.seed(random_seed)
    torch.manual_seed(random_seed)
    torch.cuda.manual_seed_all(random_seed)
    torch.backends.cudnn.deterministic = True
    torch.backends.cudnn.benchmark = False
```

with:
```
def set_seed(random_seed):
    np.random.seed(random_seed)
    random.seed(random_seed)
    torch.manual_seed(random_seed)
    if torch.cuda.is_available():
        torch.cuda.manual_seed_all(random_seed)
        torch.backends.cudnn.deterministic = True
        torch.backends.cudnn.benchmark = False
```

### Files changed
- `scripts/run_demo_batch.py`